### PR TITLE
fix wrong json formatting, closes #17

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -59,6 +59,6 @@ class aptly (
 
   file { '/etc/aptly.conf':
     ensure  => file,
-    content => inline_template("<%= @config.to_pson %>\n"),
+    content => inline_template("<%= @config.to_json %>\n"),
   }
 }


### PR DESCRIPTION
Using the function to_pson produces "JSON" which does nothing
know about data types. For aptly to access a correct configuration,
we need real JSON including data types. So we just change to_pson
to to_json.