### PR TITLE
Fix tests in Travis

### DIFF
--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -59,7 +59,9 @@ describe 'aptly' do
         :config => 'this is a string',
       }}
 
-      it { expect { should }.to raise_error(Puppet::Error, /is not a Hash/) }
+      it {
+        should raise_error(Puppet::Error, /is not a Hash/)
+      }
     end
 
     context 'rootDir and architectures' do
@@ -85,7 +87,9 @@ EOS
         :repo => 'this is a string',
       }}
 
-      it { expect { should }.to raise_error(Puppet::Error, /is not a boolean/) }
+      it {
+        should raise_error(Puppet::Error, /is not a boolean/)
+      }
     end
 
     context 'false' do

--- a/spec/defines/mirror_spec.rb
+++ b/spec/defines/mirror_spec.rb
@@ -108,7 +108,9 @@ describe 'aptly::mirror' do
         :repos    => 'this is a string',
       }}
 
-      it { expect { should }.to raise_error(Puppet::Error, /is not an Array/) }
+      it {
+        should raise_error(Puppet::Error, /is not an Array/)
+      }
     end
 
     context 'single item' do

--- a/spec/defines/repo_spec.rb
+++ b/spec/defines/repo_spec.rb
@@ -13,9 +13,7 @@ describe 'aptly::repo' do
           :command  => /aptly repo create  example$/,
           :unless   => /aptly repo show example >\/dev\/null$/,
           :user     => 'root',
-          :require  => [
-            'Class[Aptly]'
-          ],
+          :require  => 'Class[Aptly]',
       })
     }
   end
@@ -30,9 +28,7 @@ describe 'aptly::repo' do
           :command  => /aptly repo create -component="third-party" example$/,
           :unless   => /aptly repo show example >\/dev\/null$/,
           :user     => 'root',
-          :require  => [
-            'Class[Aptly]'
-          ],
+          :require  => 'Class[Aptly]',
       })
     }
 
@@ -53,9 +49,7 @@ describe 'aptly::repo' do
             :command  => /aptly repo create -component="third-party" example$/,
             :unless   => /aptly repo show example >\/dev\/null$/,
             :user     => 'custom_user',
-            :require  => [
-              'Class[Aptly]'
-            ],
+            :require  => 'Class[Aptly]',
         })
       }
     end


### PR DESCRIPTION
Several tests fail on Travis like this:

```
Failures:

  1) aptly #config not a hash should When you call a matcher in an example without a String, like this:

specify { object.should matcher }

or this:

it { should matcher }

RSpec expects the matcher to have a #description method. You should either
add a String to the example this matcher is being used in, or give it a
description method. Then you won't have to suffer this lengthy warning again.
     Failure/Error: it { expect { should }.to raise_error(Puppet::Error, /is not a Hash/) }
       expected Puppet::Error with message matching /is not a Hash/ but nothing was raised
     # ./spec/classes/init_spec.rb:62:in `block (4 levels) in <top (required)>'
```

I'm not sure what the cause of these tests failing is, and I'd appreciate somebody explaining why if they know. They don't fail locally for me and they seem to be using the same version of Rspec.

This pull request makes them easier to read as well as fixing those failures.

I also don't know what the remaining 3 failures on master are.