### PR TITLE
Make references to aptly class absolute

### DIFF
--- a/manifests/mirror.pp
+++ b/manifests/mirror.pp
@@ -42,7 +42,7 @@ define aptly::mirror (
   validate_string($keyserver)
   validate_array($repos)
 
-  include aptly
+  include ::aptly
 
   $gpg_cmd = '/usr/bin/gpg --no-default-keyring --keyring trustedkeys.gpg'
   $aptly_cmd = '/usr/bin/aptly mirror'
@@ -68,7 +68,7 @@ define aptly::mirror (
     unless  => "${aptly_cmd} show ${title} >/dev/null",
     user    => $::aptly::user,
     require => [
-      Class['aptly'],
+      Class['::aptly'],
       Exec[$exec_key_title],
     ],
   }

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -15,7 +15,7 @@ define aptly::repo(
 ){
   validate_string($component)
 
-  include aptly
+  include ::aptly
 
   $aptly_cmd = '/usr/bin/aptly repo'
 
@@ -31,7 +31,7 @@ define aptly::repo(
     unless  => "${aptly_cmd} show ${title} >/dev/null",
     user    => $::aptly::user,
     require => [
-      Class['aptly'],
+      Class['::aptly'],
     ],
   }
 }


### PR DESCRIPTION
This change fixes a dependency cycle which was observed when @tobru added support for Hiera's `create_resources` to this module in #16.

---

I don't know if the commit message is accurate or complete, so feel free to suggest changes.