### PR TITLE
Add hiera support using create_resources

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,15 +27,27 @@
 #   The user to use when performing an aptly command
 #   Default: 'root'
 #
+# [*aptly_repos*]
+#   Hash of aptly repos which is passed to aptly::repo
+#   Default: {}
+#
+# [*aptly_mirrors*]
+#   Hash of aptly mirrors which is passed to aptly::mirror
+#   Default: {}
+#
 class aptly (
   $package_ensure = present,
   $config = {},
   $repo = true,
   $key_server = undef,
   $user = 'root',
+  $aptly_repos = {},
+  $aptly_mirrors = {},
 ) {
 
   validate_hash($config)
+  validate_hash($aptly_repos)
+  validate_hash($aptly_mirrors)
   validate_bool($repo)
   validate_string($key_server)
   validate_string($user)
@@ -61,4 +73,8 @@ class aptly (
     ensure  => file,
     content => inline_template("<%= @config.to_pson %>\n"),
   }
+
+  # Hiera support
+  create_resources('::aptly::repo', $aptly_repos)
+  create_resources('::aptly::mirror', $aptly_mirrors)
 }

--- a/manifests/mirror.pp
+++ b/manifests/mirror.pp
@@ -68,7 +68,8 @@ define aptly::mirror (
     unless  => "${aptly_cmd} show ${title} >/dev/null",
     user    => $::aptly::user,
     require => [
-      Class['::aptly'],
+      Package['aptly'],
+      File['/etc/aptly.conf'],
       Exec[$exec_key_title],
     ],
   }

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -31,7 +31,8 @@ define aptly::repo(
     unless  => "${aptly_cmd} show ${title} >/dev/null",
     user    => $::aptly::user,
     require => [
-      Class['::aptly'],
+      Package['aptly'],
+      File['/etc/aptly.conf'],
     ],
   }
 }

--- a/spec/defines/mirror_spec.rb
+++ b/spec/defines/mirror_spec.rb
@@ -27,7 +27,8 @@ describe 'aptly::mirror' do
         :unless  => /aptly mirror show example >\/dev\/null$/,
         :user    => 'root',
         :require => [
-          'Class[Aptly]',
+          'Package[aptly]',
+          'File[/etc/aptly.conf]',
           'Exec[aptly_mirror_key-ABC123]'
         ],
       })
@@ -74,7 +75,8 @@ describe 'aptly::mirror' do
           :unless  => /aptly mirror show example >\/dev\/null$/,
           :user    => 'custom_user',
           :require => [
-            'Class[Aptly]',
+            'Package[aptly]',
+            'File[/etc/aptly.conf]',
             'Exec[aptly_mirror_key-ABC123]'
           ],
         })

--- a/spec/defines/repo_spec.rb
+++ b/spec/defines/repo_spec.rb
@@ -13,7 +13,7 @@ describe 'aptly::repo' do
           :command  => /aptly repo create  example$/,
           :unless   => /aptly repo show example >\/dev\/null$/,
           :user     => 'root',
-          :require  => 'Class[Aptly]',
+          :require  => [ 'Package[aptly]','File[/etc/aptly.conf]' ],
       })
     }
   end
@@ -28,7 +28,7 @@ describe 'aptly::repo' do
           :command  => /aptly repo create -component="third-party" example$/,
           :unless   => /aptly repo show example >\/dev\/null$/,
           :user     => 'root',
-          :require  => 'Class[Aptly]',
+          :require  => [ 'Package[aptly]','File[/etc/aptly.conf]' ],
       })
     }
 
@@ -49,7 +49,7 @@ describe 'aptly::repo' do
             :command  => /aptly repo create -component="third-party" example$/,
             :unless   => /aptly repo show example >\/dev\/null$/,
             :user     => 'custom_user',
-            :require  => 'Class[Aptly]',
+            :require  => [ 'Package[aptly]','File[/etc/aptly.conf]' ],
         })
       }
     end


### PR DESCRIPTION
With this addition it will be possible to use hiera directly to create repositories or mirrors. Example:
```
aptly::aptly_repos:
  myrepo:
    component: universe
```
The `require => Class['aptly']` had to be removed because this creates a circular dependency.
We now require the package and the config file instead since you may end up with repos
not in your configured rootdir if they are created before the config.

-------------------------
This supersedes #16.  It rebases it all into one commit and adds a require of `File[/etc/aptly.con']`

@tobru  are you still happy to have this commit against your name?
