### PR TITLE
Fix keyserver parameter syntax for mirror

### DIFF
--- a/manifests/mirror.pp
+++ b/manifests/mirror.pp
@@ -19,7 +19,7 @@
 #   Import the GPG key into the `trustedkeys` keyring so that aptly can
 #   verify the mirror's manifests.
 #
-# [*key_server*]
+# [*keyserver*]
 #   The keyserver to use when download the key
 #   Default: 'keyserver.ubuntu.com'
 #


### PR DESCRIPTION
Hi,

Just a fix the "keyserver" definition for mirror.

Best regards