### PR TITLE
Feature limit arch

### DIFF
--- a/spec/defines/mirror_spec.rb
+++ b/spec/defines/mirror_spec.rb
@@ -191,9 +191,9 @@ describe 'aptly::mirror' do
   describe '#architectures' do
     context 'not an array' do
       let(:params) {{
-        :location => 'http://repo.example.com',
-        :key      => 'ABC123',
-        :repos    => 'this is a string',
+        :location      => 'http://repo.example.com',
+        :key           => 'ABC123',
+        :architectures => 'this is a string',
       }}
 
       it {
@@ -201,16 +201,30 @@ describe 'aptly::mirror' do
       }
     end
 
-    context 'with array' do
+    context 'single item' do 
+      let(:params) {{
+	:location      => 'http://repo.example.com',
+	:key           => 'ABC123',
+	:architectures => ['amd64'],
+      }}
+
+      it {
+	should contain_exec('aptly_mirror_create-example').with_command(
+	  /aptly -config \/etc\/aptly.conf mirror create -architectures="amd64" -with-sources=false -with-udebs=false example http:\/\/repo\.example\.com precise$/
+	)
+      }
+    end
+
+    context 'multiple items' do
       let(:params) {{
         :location      => 'http://repo.example.com',
         :key           => 'ABC123',
-        :architectures => ['i386', 'amd64'],
+        :architectures => ['i386', 'amd64','armhf'],
       }}
 
       it {
         should contain_exec('aptly_mirror_create-example').with_command(
-          /aptly -config \/etc\/aptly.conf mirror create -architectures="i386,amd64" -with-sources=false -with-udebs=false example http:\/\/repo\.example\.com precise$/
+          /aptly -config \/etc\/aptly.conf mirror create -architectures="i386,amd64,armhf" -with-sources=false -with-udebs=false example http:\/\/repo\.example\.com precise$/
         )
       }
     end


### PR DESCRIPTION
Hi,

This branch is in relation with the issue #30. 

It adds a new optional parameter in aptly::mirror which permit to limit architectures we would like to mirror. The functionnality of the class have not been altered if this parameter is not defined.
Some tests have been added to validate this new parameter.

Unless something doesn't suit you, my work on this branch is finished.

Thomas