### PR TITLE
Extend repo,mirror add snapshot

### DIFF
--- a/manifests/mirror.pp
+++ b/manifests/mirror.pp
@@ -45,7 +45,7 @@ define aptly::mirror (
   include ::aptly
 
   $gpg_cmd = '/usr/bin/gpg --no-default-keyring --keyring trustedkeys.gpg'
-  $aptly_cmd = '/usr/bin/aptly mirror'
+  $aptly_cmd = "${::aptly::aptly_cmd} mirror"
   $exec_key_title = "aptly_mirror_key-${key}"
 
   if empty($repos) {

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -6,18 +6,47 @@
 #
 # === Parameters
 #
+# [*architectures*]
+#   Specify the list of supported architectures as an Array. If ommited Aptly
+#   assumes the repository.
+#
+# [*comment*]
+#   Specifiy a comment to be set for the repository.
+#
 # [*component*]
 #   Specify which component to put the package in. This option will only works
 #   for aptly version >= 0.5.0.
 #
+# [*distribution*]
+#   Specify the default distribution to be used when publishing this repository.
+
 define aptly::repo(
-  $component = '',
+  $architectures = [],
+  $comment       = '',
+  $component     = '',
+  $distribution  = '',
 ){
+  validate_array($architectures)
+  validate_string($comment)
   validate_string($component)
+  validate_string($distribution)
 
   include ::aptly
 
   $aptly_cmd = "${::aptly::aptly_cmd} repo"
+
+  if empty($architectures) {
+    $architectures_arg = ''
+  } else{
+    $architectures_as_s = join($architectures, ',')
+    $architectures_arg = "-architectures=\"${architectures_as_s}\""
+  }
+
+  if empty($comment) {
+    $comment_arg = ''
+  } else{
+    $comment_arg = "-comment=\"${comment}\""
+  }
 
   if empty($component) {
     $component_arg = ''
@@ -25,9 +54,14 @@ define aptly::repo(
     $component_arg = "-component=\"${component}\""
   }
 
+  if empty($distribution) {
+    $distribution_arg = ''
+  } else{
+    $distribution_arg = "-distribution=\"${distribution}\""
+  }
 
   exec{ "aptly_repo_create-${title}":
-    command => "${aptly_cmd} create ${component_arg} ${title}",
+    command => "${aptly_cmd} create ${architectures_arg} ${comment_arg} ${component_arg} ${distribution_arg} ${title}",
     unless  => "${aptly_cmd} show ${title} >/dev/null",
     user    => $::aptly::user,
     require => [

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -17,7 +17,7 @@ define aptly::repo(
 
   include ::aptly
 
-  $aptly_cmd = '/usr/bin/aptly repo'
+  $aptly_cmd = "${::aptly::aptly_cmd} repo"
 
   if empty($component) {
     $component_arg = ''

--- a/manifests/snapshot.pp
+++ b/manifests/snapshot.pp
@@ -1,0 +1,42 @@
+# == Define: aptly::snapshot
+#
+# Create a snapshot using `aptly snapshot`.
+#
+# === Parameters
+#
+# [*repo*]
+#   Create snapshot from given repo.
+#
+# [*mirror*]
+#   Create snapshot from given mirror.
+#
+define aptly::snapshot (
+  $repo   = undef,
+  $mirror = undef,
+) {
+
+  include aptly
+
+  $aptly_cmd = "${::aptly::aptly_cmd} snapshot"
+
+  if $repo and $mirror {
+    fail('$repo and $mirror are mutually exclusive.')
+  }
+  elsif $repo {
+    $aptly_args = "create ${title} from repo ${repo}"
+  }
+  elsif $mirror {
+    $aptly_args = "create ${title} from mirror ${mirror}"
+  }
+  else {
+    $aptly_args = "create ${title} empty"
+  }
+
+  exec { "aptly_snapshot_create-${title}":
+    command => "${aptly_cmd} ${aptly_args}",
+    unless  => "${aptly_cmd} show ${title} >/dev/null",
+    user    => $::aptly::user,
+    require => Class['aptly'],
+  }
+
+}

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -53,6 +53,28 @@ describe 'aptly' do
     end
   end
 
+  describe '#config_file' do
+    context 'not an absolute path' do
+      let(:params) {{
+        :config_file => 'relativepath/aptly.conf',
+      }}
+
+      it {
+        should raise_error(Puppet::Error, /is not an absolute path/)
+      }
+    end
+
+    context 'custom config path' do
+      let(:params) {{
+        :config_file => '/etc/aptly/aptly.conf',
+      }}
+
+      it {
+        should contain_file('/etc/aptly/aptly.conf')
+      }
+    end
+  end
+
   describe '#config' do
     context 'not a hash' do
       let(:params) {{
@@ -74,7 +96,7 @@ describe 'aptly' do
 
       it {
         should contain_file('/etc/aptly.conf').with_content(<<EOS
-{"rootDir":"/srv/aptly","architectures":["i386","amd64"]}
+{"architectures":["i386","amd64"],"rootDir":"/srv/aptly"}
 EOS
         )
       }

--- a/spec/defines/mirror_spec.rb
+++ b/spec/defines/mirror_spec.rb
@@ -23,8 +23,8 @@ describe 'aptly::mirror' do
 
     it {
       should contain_exec('aptly_mirror_create-example').with({
-        :command => /aptly mirror create example http:\/\/repo\.example\.com precise$/,
-        :unless  => /aptly mirror show example >\/dev\/null$/,
+        :command => /aptly -config \/etc\/aptly.conf mirror create example http:\/\/repo\.example\.com precise$/,
+        :unless  => /aptly -config \/etc\/aptly.conf mirror show example >\/dev\/null$/,
         :user    => 'root',
         :require => [
           'Package[aptly]',
@@ -71,8 +71,8 @@ describe 'aptly::mirror' do
 
       it {
         should contain_exec('aptly_mirror_create-example').with({
-          :command => /aptly mirror create example http:\/\/repo\.example\.com precise$/,
-          :unless  => /aptly mirror show example >\/dev\/null$/,
+          :command => /aptly -config \/etc\/aptly.conf mirror create example http:\/\/repo\.example\.com precise$/,
+          :unless  => /aptly -config \/etc\/aptly.conf mirror show example >\/dev\/null$/,
           :user    => 'custom_user',
           :require => [
             'Package[aptly]',
@@ -124,7 +124,7 @@ describe 'aptly::mirror' do
 
       it {
         should contain_exec('aptly_mirror_create-example').with_command(
-          /aptly mirror create example http:\/\/repo\.example\.com precise main$/
+          /aptly -config \/etc\/aptly.conf mirror create example http:\/\/repo\.example\.com precise main$/
         )
       }
     end
@@ -138,7 +138,7 @@ describe 'aptly::mirror' do
 
       it {
         should contain_exec('aptly_mirror_create-example').with_command(
-          /aptly mirror create example http:\/\/repo\.example\.com precise main contrib non-free$/
+          /aptly -config \/etc\/aptly.conf mirror create example http:\/\/repo\.example\.com precise main contrib non-free$/
         )
       }
     end

--- a/spec/defines/mirror_spec.rb
+++ b/spec/defines/mirror_spec.rb
@@ -23,7 +23,7 @@ describe 'aptly::mirror' do
 
     it {
       should contain_exec('aptly_mirror_create-example').with({
-        :command => /aptly -config \/etc\/aptly.conf mirror create example http:\/\/repo\.example\.com precise$/,
+        :command => /aptly -config \/etc\/aptly.conf mirror create *-with-sources=false -with-udebs=false example http:\/\/repo\.example\.com precise$/,
         :unless  => /aptly -config \/etc\/aptly.conf mirror show example >\/dev\/null$/,
         :user    => 'root',
         :require => [
@@ -71,7 +71,7 @@ describe 'aptly::mirror' do
 
       it {
         should contain_exec('aptly_mirror_create-example').with({
-          :command => /aptly -config \/etc\/aptly.conf mirror create example http:\/\/repo\.example\.com precise$/,
+          :command => /aptly -config \/etc\/aptly.conf mirror create *-with-sources=false -with-udebs=false example http:\/\/repo\.example\.com precise$/,
           :unless  => /aptly -config \/etc\/aptly.conf mirror show example >\/dev\/null$/,
           :user    => 'custom_user',
           :require => [
@@ -124,7 +124,7 @@ describe 'aptly::mirror' do
 
       it {
         should contain_exec('aptly_mirror_create-example').with_command(
-          /aptly -config \/etc\/aptly.conf mirror create example http:\/\/repo\.example\.com precise main$/
+          /aptly -config \/etc\/aptly.conf mirror create *-with-sources=false -with-udebs=false example http:\/\/repo\.example\.com precise main$/
         )
       }
     end
@@ -138,9 +138,94 @@ describe 'aptly::mirror' do
 
       it {
         should contain_exec('aptly_mirror_create-example').with_command(
-          /aptly -config \/etc\/aptly.conf mirror create example http:\/\/repo\.example\.com precise main contrib non-free$/
+          /aptly -config \/etc\/aptly.conf mirror create *-with-sources=false -with-udebs=false example http:\/\/repo\.example\.com precise main contrib non-free$/
         )
       }
     end
   end
+
+  describe '#architectures' do
+    context 'not an array' do
+      let(:params) {{
+        :location => 'http://repo.example.com',
+        :key      => 'ABC123',
+        :repos    => 'this is a string',
+      }}
+
+      it {
+        should raise_error(Puppet::Error, /is not an Array/)
+      }
+    end
+
+    context 'with array' do
+      let(:params) {{
+        :location      => 'http://repo.example.com',
+        :key           => 'ABC123',
+        :architectures => ['i386', 'amd64'],
+      }}
+
+      it {
+        should contain_exec('aptly_mirror_create-example').with_command(
+          /aptly -config \/etc\/aptly.conf mirror create -architectures="i386,amd64" -with-sources=false -with-udebs=false example http:\/\/repo\.example\.com precise$/
+        )
+      }
+    end
+  end
+
+  describe '#with_sources' do
+    context 'not a boolean' do
+      let(:params) {{
+        :location     => 'http://repo.example.com',
+        :key          => 'ABC123',
+        :with_sources => 'this is a string',
+      }}
+
+      it {
+        should raise_error(Puppet::Error, /is not a boolean/)
+      }
+    end
+
+    context 'with boolean true' do
+      let(:params) {{
+        :location     => 'http://repo.example.com',
+        :key          => 'ABC123',
+        :with_sources => true,
+      }}
+
+      it {
+        should contain_exec('aptly_mirror_create-example').with_command(
+          /aptly -config \/etc\/aptly.conf mirror create *-with-sources=true -with-udebs=false example http:\/\/repo\.example\.com precise$/
+        )
+      }
+    end
+  end
+
+  describe '#with_udebs' do
+    context 'not a boolean' do
+      let(:params) {{
+        :location   => 'http://repo.example.com',
+        :key        => 'ABC123',
+        :with_udebs => 'this is a string',
+      }}
+
+      it {
+        should raise_error(Puppet::Error, /is not a boolean/)
+      }
+    end
+
+    context 'with boolean true' do
+      let(:params) {{
+        :location   => 'http://repo.example.com',
+        :key        => 'ABC123',
+        :with_udebs => true,
+      }}
+
+      it {
+        should contain_exec('aptly_mirror_create-example').with_command(
+          /aptly -config \/etc\/aptly.conf mirror create *-with-sources=false -with-udebs=true example http:\/\/repo\.example\.com precise$/
+        )
+      }
+    end
+  end
+
 end

--- a/spec/defines/repo_spec.rb
+++ b/spec/defines/repo_spec.rb
@@ -10,7 +10,7 @@ describe 'aptly::repo' do
   describe 'param defaults' do
     it {
         should contain_exec('aptly_repo_create-example').with({
-          :command  => /aptly -config \/etc\/aptly.conf repo create  example$/,
+          :command  => /aptly -config \/etc\/aptly.conf repo create *example$/,
           :unless   => /aptly -config \/etc\/aptly.conf repo show example >\/dev\/null$/,
           :user     => 'root',
           :require  => [ 'Package[aptly]','File[/etc/aptly.conf]' ],
@@ -25,7 +25,7 @@ describe 'aptly::repo' do
 
     it {
         should contain_exec('aptly_repo_create-example').with({
-          :command  => /aptly -config \/etc\/aptly.conf repo create -component="third-party" example$/,
+          :command  => /aptly -config \/etc\/aptly.conf repo create *-component="third-party" *example$/,
           :unless   => /aptly -config \/etc\/aptly.conf repo show example >\/dev\/null$/,
           :user     => 'root',
           :require  => [ 'Package[aptly]','File[/etc/aptly.conf]' ],
@@ -46,7 +46,7 @@ describe 'aptly::repo' do
 
       it {
           should contain_exec('aptly_repo_create-example').with({
-            :command  => /aptly -config \/etc\/aptly.conf repo create -component="third-party" example$/,
+            :command  => /aptly -config \/etc\/aptly.conf repo create *-component="third-party" *example$/,
             :unless   => /aptly -config \/etc\/aptly.conf repo show example >\/dev\/null$/,
             :user     => 'custom_user',
             :require  => [ 'Package[aptly]','File[/etc/aptly.conf]' ],
@@ -54,4 +54,62 @@ describe 'aptly::repo' do
       }
     end
   end
+
+  describe 'user defined architectures' do
+    context 'passing valid values' do
+      let(:params){{
+        :architectures => ['i386','amd64'],
+      }}
+
+      it {
+        should contain_exec('aptly_repo_create-example').with({
+          :command  => /aptly -config \/etc\/aptly.conf repo create *-architectures="i386,amd64" *example$/,
+          :unless   => /aptly -config \/etc\/aptly.conf repo show example >\/dev\/null$/,
+          :user     => 'root',
+          :require  => [ 'Package[aptly]','File[/etc/aptly.conf]' ],
+        })
+      }
+    end
+
+    context 'passing invalid values' do
+      let(:params){{
+        :architectures => 'amd64'
+      }}
+
+      it {
+        should raise_error(Puppet::Error, /is not an Array/)
+      }
+    end
+  end
+
+  describe 'user defined comment' do
+    let(:params){{
+      :comment => 'example comment',
+    }}
+
+    it {
+      should contain_exec('aptly_repo_create-example').with({
+        :command  => /aptly -config \/etc\/aptly.conf repo create *-comment="example comment" *example$/,
+        :unless   => /aptly -config \/etc\/aptly.conf repo show example >\/dev\/null$/,
+        :user     => 'root',
+        :require  => [ 'Package[aptly]','File[/etc/aptly.conf]' ],
+      })
+    }
+  end
+
+  describe 'user defined distribution' do
+    let(:params){{
+      :distribution => 'example_distribution',
+    }}
+
+    it {
+      should contain_exec('aptly_repo_create-example').with({
+        :command  => /aptly -config \/etc\/aptly.conf repo create *-distribution="example_distribution" *example$/,
+        :unless   => /aptly -config \/etc\/aptly.conf repo show example >\/dev\/null$/,
+        :user     => 'root',
+        :require  => [ 'Package[aptly]','File[/etc/aptly.conf]' ],
+      })
+    }
+  end
+
 end

--- a/spec/defines/repo_spec.rb
+++ b/spec/defines/repo_spec.rb
@@ -10,8 +10,8 @@ describe 'aptly::repo' do
   describe 'param defaults' do
     it {
         should contain_exec('aptly_repo_create-example').with({
-          :command  => /aptly repo create  example$/,
-          :unless   => /aptly repo show example >\/dev\/null$/,
+          :command  => /aptly -config \/etc\/aptly.conf repo create  example$/,
+          :unless   => /aptly -config \/etc\/aptly.conf repo show example >\/dev\/null$/,
           :user     => 'root',
           :require  => [ 'Package[aptly]','File[/etc/aptly.conf]' ],
       })
@@ -25,8 +25,8 @@ describe 'aptly::repo' do
 
     it {
         should contain_exec('aptly_repo_create-example').with({
-          :command  => /aptly repo create -component="third-party" example$/,
-          :unless   => /aptly repo show example >\/dev\/null$/,
+          :command  => /aptly -config \/etc\/aptly.conf repo create -component="third-party" example$/,
+          :unless   => /aptly -config \/etc\/aptly.conf repo show example >\/dev\/null$/,
           :user     => 'root',
           :require  => [ 'Package[aptly]','File[/etc/aptly.conf]' ],
       })
@@ -46,8 +46,8 @@ describe 'aptly::repo' do
 
       it {
           should contain_exec('aptly_repo_create-example').with({
-            :command  => /aptly repo create -component="third-party" example$/,
-            :unless   => /aptly repo show example >\/dev\/null$/,
+            :command  => /aptly -config \/etc\/aptly.conf repo create -component="third-party" example$/,
+            :unless   => /aptly -config \/etc\/aptly.conf repo show example >\/dev\/null$/,
             :user     => 'custom_user',
             :require  => [ 'Package[aptly]','File[/etc/aptly.conf]' ],
         })

--- a/spec/defines/snapshot_spec.rb
+++ b/spec/defines/snapshot_spec.rb
@@ -1,0 +1,64 @@
+require 'spec_helper'
+
+describe 'aptly::snapshot' do
+  let(:title) { 'example' }
+
+  let(:facts){{
+    :lsbdistid => 'ubuntu',
+  }}
+
+  describe 'param defaults' do
+    it {
+        should contain_exec('aptly_snapshot_create-example').with({
+          :command  => /aptly -config \/etc\/aptly.conf snapshot create example empty$/,
+          :unless   => /aptly -config \/etc\/aptly.conf snapshot show example >\/dev\/null$/,
+          :user     => 'root',
+          :require  => 'Class[Aptly]',
+      })
+    }
+  end
+
+  describe 'user defined params' do
+    context 'passing both params' do
+      let(:params){{
+        :repo   => 'example_repo',
+        :mirror => 'example_mirror',
+      }}
+
+      it {
+        should raise_error(Puppet::Error, /mutually exclusive/)
+      }
+    end
+
+    context 'passing repo param' do
+      let(:params){{
+        :repo   => 'example_repo',
+      }}
+
+      it {
+          should contain_exec('aptly_snapshot_create-example').with({
+            :command  => /aptly -config \/etc\/aptly.conf snapshot create example from repo example_repo$/,
+            :unless   => /aptly -config \/etc\/aptly.conf snapshot show example >\/dev\/null$/,
+            :user     => 'root',
+            :require  => 'Class[Aptly]',
+        })
+      }
+    end
+
+    context 'passing mirror param' do
+      let(:params){{
+        :mirror   => 'example_mirror',
+      }}
+
+      it {
+          should contain_exec('aptly_snapshot_create-example').with({
+            :command  => /aptly -config \/etc\/aptly.conf snapshot create example from mirror example_mirror$/,
+            :unless   => /aptly -config \/etc\/aptly.conf snapshot show example >\/dev\/null$/,
+            :user     => 'root',
+            :require  => 'Class[Aptly]',
+        })
+      }
+    end
+
+  end
+end


### PR DESCRIPTION
Hi,

a few words about these changes:
1. init: config_file:
We required to use a custom path for Aptly configuration in the past. Meanwhile we use default paths too, but I wonder if it might still be helpful?

2. adding snapshot.pp
We use additional scripts to automate updating any of the mirrors Puppet creates. In this regards it was easier to provide snapshots already from beginning when we need to took care of failure handling in those scripts. It's probably not useful to most users but hopefully useful enough to keep it included?

3. adding attributes to repo.pp
Our internal Apt structure required to define the default distribution of the repository. Other parameters were added as we evaluated Aptly. They seem reasonable enough to keep them.

4. adding attributes to mirror.pp
Quite similar to last paragraph we included additional arguments while evaluating Aptly. 'with_sources' is important for our build-hosts while 'with_udebs' must be included to setup proper mirrors for serving installation packages (i.e. PXE installations from local mirror). Restricting the list of architectures helps us to control the disk space needed for our mirrors.

Let me know if you have any doubts to merge these changes!
Cheers!
Mathias
