### PR TITLE
Use full 40-characters key id

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -64,7 +64,7 @@ class aptly (
       release     => 'squeeze',
       repos       => 'main',
       key_server  => $key_server,
-      key         => '2A194991',
+      key         => 'B6140515643C2AE155596690E083A3782A194991',
       include_src => false,
     }
 


### PR DESCRIPTION
Puppet `apt` module warns about short fingerprint id's due to security (short fingerprints are susceptible to collision attacks).
Here is an example of the warning:
`Warning: /Apt_key[Add key: 2A194991 from Apt::Source aptly]: The id should be a full fingerprint (40 characters), see README.`
This change updates to the full key id.