### PR TITLE
Don't add key if not present

### DIFF
--- a/manifests/mirror.pp
+++ b/manifests/mirror.pp
@@ -18,7 +18,7 @@
 # [*key*]
 #   Import the GPG key into the `trustedkeys` keyring so that aptly can
 #   verify the mirror's manifests. May be specified as string or array for
-#   multiple keys.
+#   multiple keys. If not specified, no action will be taken.
 #
 # [*keyserver*]
 #   The keyserver to use when download the key
@@ -82,19 +82,21 @@ define aptly::mirror (
     $components_arg = " ${components}"
   }
 
-  if is_array($key) {
-    $key_string = join($key, "' '")
-  } elsif is_string($key) {
-    $key_string = $key
-  } else {
-    fail('$key is neither a string nor an array!')
-  }
+  if $key {
+    if is_array($key) {
+      $key_string = join($key, "' '")
+    } elsif is_string($key) {
+      $key_string = $key
+    } else {
+      fail('$key is neither a string nor an array!')
+    }
 
-  exec { "aptly_mirror_gpg-${title}":
-    path    => '/bin:/usr/bin',
-    command => "${gpg_cmd} --keyserver '${keyserver}' --recv-keys '${key_string}'",
-    unless  => "echo '${key_string}' | xargs -n1 ${gpg_cmd} --list-keys",
-    user    => $::aptly::user,
+    exec { "aptly_mirror_gpg-${title}":
+      path    => '/bin:/usr/bin',
+      command => "${gpg_cmd} --keyserver '${keyserver}' --recv-keys '${key_string}'",
+      unless  => "echo '${key_string}' | xargs -n1 ${gpg_cmd} --list-keys",
+      user    => $::aptly::user,
+    }
   }
 
   exec { "aptly_mirror_create-${title}":

--- a/manifests/mirror.pp
+++ b/manifests/mirror.pp
@@ -97,16 +97,23 @@ define aptly::mirror (
       unless  => "echo '${key_string}' | xargs -n1 ${gpg_cmd} --list-keys",
       user    => $::aptly::user,
     }
+
+    $exec_aptly_mirror_create_require = [
+      Package['aptly'],
+      File['/etc/aptly.conf'],
+      Exec["aptly_mirror_gpg-${title}"],
+    ]
+  } else {
+    $exec_aptly_mirror_create_require = [
+      Package['aptly'],
+      File['/etc/aptly.conf'],
+    ]
   }
 
   exec { "aptly_mirror_create-${title}":
     command => "${aptly_cmd} create ${architectures_arg} -with-sources=${with_sources} -with-udebs=${with_udebs} ${title} ${location} ${release}${components_arg}",
     unless  => "${aptly_cmd} show ${title} >/dev/null",
     user    => $::aptly::user,
-    require => [
-      Package['aptly'],
-      File['/etc/aptly.conf'],
-      Exec["aptly_mirror_gpg-${title}"],
-    ],
+    require => $exec_aptly_mirror_create_require,
   }
 }

--- a/spec/defines/mirror_spec.rb
+++ b/spec/defines/mirror_spec.rb
@@ -144,6 +144,18 @@ describe 'aptly::mirror' do
         })
       }
     end
+
+    context 'no key passed' do
+      let(:params) {
+        {
+          :location   => 'http://repo.example.com',
+        }
+      }
+
+      it {
+        should_not contain_exec('aptly_mirror_gpg-example')
+      }
+    end
   end
 
   describe '#repos' do


### PR DESCRIPTION
This patch makes it possible to create mirrors without importing the corresponding gpg key. The reason why we would like that is eg the key is not in a keyserver and needs to be imported manually.