### PR TITLE
Fixed type check of keys

### DIFF
--- a/manifests/mirror.pp
+++ b/manifests/mirror.pp
@@ -84,7 +84,7 @@ define aptly::mirror (
 
   if is_array($key) {
     $key_string = join($key, "' '")
-  } elsif is_string($key) {
+  } elsif is_string($key) or is_integer($key) {
     $key_string = $key
   } else {
     fail('$key is neither a string nor an array!')


### PR DESCRIPTION
Key can be integer (because of strange Puppet type conversion if key fingerprint contains only numbers)