### PR TITLE
Release v0.4.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,20 @@
+2015-12-04 Release 0.4.0
+- Drop support for Puppet 2.7 and for Puppet 3.1 but only on Ruby 2
+- Start running tests against Puppet 3.6 and 3.7
+- Add a defined type `aptly::snapshot` to create Aptly snapshots (thanks @mklette)
+- Add `$architectures`, `$with_sources` and `$with_udebs` parameters to
+  `aptly::mirror` (thanks @mklette and @dw-thomast)
+- Add `$architectures`, `$comment` and `$distribution` parameters to
+  `aptly::repo` (thanks @mklette)
+- Add `$config_file` and `$config_contents` parameters to `aptly` class
+  to allow changing the location on disk and contents of the config file
+  (thanks @mklette and @antonio)
+- Allow an `aptly::mirror` to have more than one key (thanks @dw-thomast)
+- Use full 40 character key for `repo.aptly.info` as short fingerprints are
+  susceptible to collision attacks (thanks @amosshapira)
+- Fix type check of `$key` in `aptly::mirror` (thanks @sw0x2A)
+- Fix comment in `aptly::mirror` (thanks @zeysh)
+
 2015-04-23 Release 0.3.0
 - Add an `aptly::api` class for configuring aptly's API service.
 - Add support for specifying repos and mirrors in hieradata.

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "gdsoperations-aptly",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": "gdsoperations",
   "license": "MIT",
   "summary": "Module to manage aptly",


### PR DESCRIPTION
I've bumped this to 1.0.0 which I believe is in line with [Semantic Versioning 2.0.0](http://semver.org/) because of the change in Puppet version support.

Diff: https://github.com/gds-operations/puppet-aptly/compare/v0.3.0...gds-operations:f0683f8

Sorry this took such a long time to release. The changes are:

- Drop support for Puppet 2.7 and for Puppet 3.1 but only on Ruby 2
- Start running tests against Puppet 3.6 and 3.7
- Add a defined type `aptly::snapshot` to create Aptly snapshots (thanks @mklette)
- Add `$architectures`, `$with_sources` and `$with_udebs` parameters to `aptly::mirror` (thanks @mklette and @dw-thomast)
- Add `$architectures`, `$comment` and `$distribution` parameters to `aptly::repo` (thanks @mklette)
- Add `$config_file` and `$config_contents` parameters to `aptly` class to allow changing the location on disk and contents of the config file (thanks @mklette and @antonio)
- Allow an `aptly::mirror` to have more than one key (thanks @dw-thomast)
- Use full 40 character key for `repo.aptly.info` as short fingerprints are susceptible to collision attacks (thanks @amosshapira)
- Fix type check of `$key` in `aptly::mirror` (thanks @sw0x2A)
- Fix comment in `aptly::mirror` (thanks @zeysh)
