### PR TITLE
Support for puppetlabs-apt > 2.0 fixes #34

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,6 +5,6 @@ fixtures:
       ref: "3.0.0"
     apt:
       repo: "git://github.com/puppetlabs/puppetlabs-apt.git"
-      ref: "1.8.0"
+      ref: "2.2.0"
   symlinks:
     aptly: "#{source_dir}"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Unreleased
+- Update support for puppetlabs/apt from version 1-2 to version 2-3
+  (thanks @zxjinn)
+
 2015-12-04 Release 0.4.0
 - Drop support for Puppet 2.7 and for Puppet 3.1 but only on Ruby 2
 - Start running tests against Puppet 3.6 and 3.7

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -69,12 +69,11 @@ class aptly (
 
   if $repo {
     apt::source { 'aptly':
-      location    => 'http://repo.aptly.info',
-      release     => 'squeeze',
-      repos       => 'main',
-      key_server  => $key_server,
-      key         => 'B6140515643C2AE155596690E083A3782A194991',
-      include_src => false,
+      location   => 'http://repo.aptly.info',
+      release    => 'squeeze',
+      repos      => 'main',
+      key_server => $key_server,
+      key        => 'B6140515643C2AE155596690E083A3782A194991',
     }
 
     Apt::Source['aptly'] -> Package['aptly']

--- a/manifests/mirror.pp
+++ b/manifests/mirror.pp
@@ -4,8 +4,6 @@
 # or publish the mirror for you, because it will take a long time and it
 # doesn't make sense to schedule these actions frequenly in Puppet.
 #
-# The parameters are intended to be analogous to `apt::source`.
-#
 # NB: This will not recreate the mirror if the params change! You will need
 # to manually `aptly mirror drop <name>` after also dropping all snapshot
 # and publish references.

--- a/metadata.json
+++ b/metadata.json
@@ -7,7 +7,7 @@
   "source": "https://github.com/gds-operations/puppet-aptly",
   "dependencies": [
     {"name": "puppetlabs/stdlib", "version_requirement": ">=3.0.0"},
-    {"name": "puppetlabs/apt", "version_requirement": ">=1.0.0 <2.0.0"}
+    {"name": "puppetlabs/apt", "version_requirement": ">=2.0.0 <3.0.0"}
   ],
   "project_page": "https://github.com/gds-operations/puppet-aptly"
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe 'aptly' do
   let(:facts) {{
     :lsbdistid => 'Debian',
+    :osfamily  => 'Debian',
   }}
 
   context 'param defaults' do
@@ -30,16 +31,6 @@ describe 'aptly' do
   end
 
   describe '#key_server (with #repo default to true)' do
-    context "undef (default)" do
-      let(:params) {{ }}
-
-      it "should let apt::source decide the default (keyserver.ubuntu.com)" do
-        should contain_apt__source('aptly').with(
-          :key_server => 'keyserver.ubuntu.com',
-        )
-      end
-    end
-
     context 'custom key_server' do
       let(:params) {{
         :key_server => 'somekeyserver.com',

--- a/spec/defines/mirror_spec.rb
+++ b/spec/defines/mirror_spec.rb
@@ -5,6 +5,7 @@ describe 'aptly::mirror' do
   let(:facts) {{
     :lsbdistid       => 'Debian',
     :lsbdistcodename => 'precise',
+    :osfamily        => 'Debian',
   }}
 
   describe 'param defaults and mandatory' do

--- a/spec/defines/repo_spec.rb
+++ b/spec/defines/repo_spec.rb
@@ -5,6 +5,7 @@ describe 'aptly::repo' do
 
   let(:facts){{
     :lsbdistid => 'ubuntu',
+    :osfamily  => 'Debian',
   }}
 
   describe 'param defaults' do

--- a/spec/defines/snapshot_spec.rb
+++ b/spec/defines/snapshot_spec.rb
@@ -5,6 +5,7 @@ describe 'aptly::snapshot' do
 
   let(:facts){{
     :lsbdistid => 'ubuntu',
+    :osfamily  => 'Debian',
   }}
 
   describe 'param defaults' do

--- a/spec/spec_helper_system.rb
+++ b/spec/spec_helper_system.rb
@@ -12,6 +12,6 @@ RSpec.configure do |c|
     puppet_install
     puppet_module_install(:source => proj_root, :module_name => 'aptly')
     shell('puppet module install puppetlabs-stdlib')
-    shell('puppet module install puppetlabs-apt --version 1.8.0')
+    shell('puppet module install puppetlabs-apt --version 2.2.0')
   end
 end


### PR DESCRIPTION
This is a rebased version of #40 with the commit history tidied slightly.

I've also modified `.fixtures.yml` to use a version of puppetlabs-apt between 2.0.0 and 3.0.0.