### PR TITLE
Don't add key if not present

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 Unreleased
 - Update support for puppetlabs/apt from version 1-2 to version 2-3
   (thanks @zxjinn)
+- Do not run an exec to add a GPG key in `aptly::mirror` if no
+  GPG key is provided (thanks @antonio)
 
 2015-12-04 Release 0.4.0
 - Drop support for Puppet 2.7 and for Puppet 3.1 but only on Ruby 2

--- a/spec/defines/mirror_spec.rb
+++ b/spec/defines/mirror_spec.rb
@@ -145,6 +145,18 @@ describe 'aptly::mirror' do
         })
       }
     end
+
+    context 'no key passed' do
+      let(:params) {
+        {
+          :location => 'http://repo.example.com',
+        }
+      }
+
+      it {
+        should_not contain_exec('aptly_mirror_gpg-example')
+      }
+    end
   end
 
   describe '#repos' do


### PR DESCRIPTION
This patch makes it possible to create mirrors without importing the corresponding gpg key. The reason why we would like that is eg the key is not in a keyserver and needs to be imported manually.

This is a copy of #36 rebased with master.