### PR TITLE
Release 0.5.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-Unreleased
+2016-02-26 Release 0.5.0
 - Update support for puppetlabs/apt from version 1-2 to version 2-3
   (thanks @zxjinn)
 - Do not run an exec to add a GPG key in `aptly::mirror` if no

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "gdsoperations-aptly",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "author": "Government Digital Service",
   "license": "MIT",
   "summary": "Module to manage aptly",


### PR DESCRIPTION
- Update support for puppetlabs/apt from version 1-2 to version 2-3 (thanks @zxjinn)
- Do not run an exec to add a GPG key in `aptly::mirror` if no GPG key is provided (thanks @antonio)