### PR TITLE
Run `apt::update` before installing package

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -76,7 +76,7 @@ class aptly (
       key        => 'B6140515643C2AE155596690E083A3782A194991',
     }
 
-    Apt::Source['aptly'] -> Package['aptly']
+    Apt::Source['aptly'] -> Class['apt::update'] -> Package['aptly']
   }
 
   package { 'aptly':

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -10,7 +10,7 @@ describe 'aptly' do
     let(:params) {{ }}
 
     it { should contain_apt__source('aptly') }
-    it { should contain_package('aptly').that_requires('Apt::Source[aptly]') }
+    it { should contain_package('aptly').that_requires('Apt::Update') }
     it { should contain_file('/etc/aptly.conf').with_content("{}\n") }
   end
 


### PR DESCRIPTION
https://github.com/gds-operations/puppet-aptly/issues/48

> every time I ran Puppet for the 1st time, it fails to install aptly

This is because `apt::source` schedules `apt::update` to happen at the end of the Puppet run, but by that time we've already attempted to install the package.

This commit introduces a dependency between `apt::update` and the package resource.