### PR TITLE
Add parameter for `-no-lock` option

### DIFF
--- a/manifests/api.pp
+++ b/manifests/api.pp
@@ -23,13 +23,18 @@
 # [*log*]
 #   Enable or disable Upstart logging.
 #   Default: none
-
+#
+# [*enable_cli_and_http*]
+#   Enable concurrent use of command line (CLI) and HTTP APIs with
+#   the same Aptly root.
+#
 class aptly::api (
-  $ensure         = running,
-  $user           = 'root',
-  $group          = 'root',
-  $listen         = ':8080',
-  $log            = 'none',
+  $ensure              = running,
+  $user                = 'root',
+  $group               = 'root',
+  $listen              = ':8080',
+  $log                 = 'none',
+  $enable_cli_and_http = false,
   ) {
 
     validate_re($ensure, ['^stopped|running$'], 'Valid values for $ensure: stopped, running')

--- a/spec/classes/api_spec.rb
+++ b/spec/classes/api_spec.rb
@@ -131,4 +131,18 @@ describe 'aptly::api' do
       it { should raise_error(Puppet::Error, /Valid values for \$log: none, log/) }
     end
   end
+
+  describe 'enable_cli_and_http' do
+    context 'false (default)' do
+      it { should contain_file('aptly-upstart').without_content(/ -no-lock/) }
+    end
+
+    context 'true' do
+      let(:params) {{
+        :enable_cli_and_http => true
+      }}
+
+      it { should contain_file('aptly-upstart').with_content(/ -no-lock/) }
+    end
+  end
 end

--- a/templates/etc/aptly.init.erb
+++ b/templates/etc/aptly.init.erb
@@ -8,4 +8,4 @@ console <%= @log %>
 setuid <%= @user %>
 setgid <%= @group %>
 
-exec /usr/bin/aptly api serve -listen=<%= @listen %>
+exec /usr/bin/aptly api serve -listen=<%= @listen %><% if @enable_cli_and_http %> -no-lock<% end %>


### PR DESCRIPTION
http://www.aptly.info/doc/api/

The `-no-lock` option allows the CLI and HTTP API to be used concurrently.

It's set to false to maintain the current behaviour.

Requested in #53.