### PR TITLE
Update the repo GPG key.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -73,7 +73,7 @@ class aptly (
       release    => 'squeeze',
       repos      => 'main',
       key_server => $key_server,
-      key        => 'B6140515643C2AE155596690E083A3782A194991',
+      key        => 'DF32BC15E2145B3FA151AED19E3E53F19C7DE460',
     }
 
     Apt::Source['aptly'] -> Class['apt::update'] -> Package['aptly']


### PR DESCRIPTION
The previous one has expired and been replaced. See
https://github.com/smira/aptly/issues/364 for details.