### PR TITLE
Zipkid feature/puppet exec env proxy

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+2016-06-14 Release 0.7.0
+- Add `environment` parameter (thanks @zipkid)
+
 2016-06-03 Release 0.6.0
 - Support Ruby 2.1.0 and 2.2.0
 - Support Puppet 3.8

--- a/manifests/mirror.pp
+++ b/manifests/mirror.pp
@@ -45,6 +45,10 @@
 #   Boolean to control whether Aptly should also download .udeb packages.
 #   Default: false
 #
+# [*environment*]
+#   Optional environment variables to pass to the exec.
+#   Example: ['http_proxy=http://127.0.0.2:3128']
+#   Default: []
 define aptly::mirror (
   $location,
   $key           = undef,
@@ -54,12 +58,14 @@ define aptly::mirror (
   $repos         = [],
   $with_sources  = false,
   $with_udebs    = false,
+  $environment   = [],
 ) {
   validate_string($keyserver)
   validate_array($repos)
   validate_array($architectures)
   validate_bool($with_sources)
   validate_bool($with_udebs)
+  validate_array($environment)
 
   include ::aptly
 
@@ -109,9 +115,10 @@ define aptly::mirror (
   }
 
   exec { "aptly_mirror_create-${title}":
-    command => "${aptly_cmd} create ${architectures_arg} -with-sources=${with_sources} -with-udebs=${with_udebs} ${title} ${location} ${release}${components_arg}",
-    unless  => "${aptly_cmd} show ${title} >/dev/null",
-    user    => $::aptly::user,
-    require => $exec_aptly_mirror_create_require,
+    command     => "${aptly_cmd} create ${architectures_arg} -with-sources=${with_sources} -with-udebs=${with_udebs} ${title} ${location} ${release}${components_arg}",
+    unless      => "${aptly_cmd} show ${title} >/dev/null",
+    user        => $::aptly::user,
+    require     => $exec_aptly_mirror_create_require,
+    environment => $environment,
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "gdsoperations-aptly",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "author": "Government Digital Service",
   "license": "MIT",
   "summary": "Module to manage aptly",

--- a/spec/defines/mirror_spec.rb
+++ b/spec/defines/mirror_spec.rb
@@ -103,6 +103,47 @@ describe 'aptly::mirror' do
     end
   end
 
+  describe '#environment' do
+    context 'not an array' do
+      let(:params){{
+        :location    => 'http://repo.example.com',
+        :key         => 'ABC123',
+        :environment => 'FOO=bar',
+      }}
+
+      it {
+        should raise_error(Puppet::Error, /is not an Array/)
+      }
+    end
+
+    context 'defaults to empty array' do
+      let(:params){{
+        :location    => 'http://repo.example.com',
+        :key         => 'ABC123',
+      }}
+
+      it {
+        should contain_exec('aptly_mirror_create-example').with({
+          :environment => [],
+        })
+      }
+    end
+
+    context 'with FOO set to bar' do
+      let(:params){{
+        :location    => 'http://repo.example.com',
+        :key         => [ 'ABC123' ],
+        :environment => ['FOO=bar'],
+      }}
+
+      it{
+        should contain_exec('aptly_mirror_create-example').with({
+          :environment => ['FOO=bar'],
+        })
+      }
+    end
+  end
+
   describe '#key' do
     context 'single item not in an array' do
       let(:params){{


### PR DESCRIPTION
Add the `environment` parameter to `aptly::mirror`.

Supersedes #59 with the addition of spec tests and a version bump.

With thanks to @zipkid for the original contribution.