### PR TITLE
Add filter and filterwithdeps parameters

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,3 +20,7 @@ gem 'puppet-syntax', '2.0.0'
 # dependency of the system tests.
 gem 'fog', '1.34.0'
 gem 'fog-google', '0.1.0'
+
+# Older version required for ruby 1.9 compatability, as it is pulled in as dependency
+# of Puppet.  Versions of json_pure greater than 2.0.1 require Ruby 2.
+gem 'json_pure', '<= 2.0.1'

--- a/manifests/mirror.pp
+++ b/manifests/mirror.pp
@@ -22,6 +22,9 @@
 #   The keyserver to use when download the key
 #   Default: 'keyserver.ubuntu.com'
 #
+# [*filter*]
+#   Package query that is applied to packages in the mirror
+#
 # [*release*]
 #   Distribution to mirror for.
 #   Default: `$::lsbdistcodename`
@@ -45,24 +48,33 @@
 #   Boolean to control whether Aptly should also download .udeb packages.
 #   Default: false
 #
+# [*filter_with_deps*]
+#   Boolean to control whether when filtering to include dependencies of matching 
+#   packages as well
+#   Default: false
+#
 # [*environment*]
 #   Optional environment variables to pass to the exec.
 #   Example: ['http_proxy=http://127.0.0.2:3128']
 #   Default: []
 define aptly::mirror (
   $location,
-  $key           = undef,
-  $keyserver     = 'keyserver.ubuntu.com',
-  $release       = $::lsbdistcodename,
-  $architectures = [],
-  $repos         = [],
-  $with_sources  = false,
-  $with_udebs    = false,
-  $environment   = [],
+  $key              = undef,
+  $keyserver        = 'keyserver.ubuntu.com',
+  $filter           = '',
+  $release          = $::lsbdistcodename,
+  $architectures    = [],
+  $repos            = [],
+  $with_sources     = false,
+  $with_udebs       = false,
+  $filter_with_deps = false,
+  $environment      = [],
 ) {
   validate_string($keyserver)
+  validate_string($filter)
   validate_array($repos)
   validate_array($architectures)
+  validate_bool($filter_with_deps)
   validate_bool($with_sources)
   validate_bool($with_udebs)
   validate_array($environment)
@@ -84,6 +96,18 @@ define aptly::mirror (
   } else {
     $components = join($repos, ' ')
     $components_arg = " ${components}"
+  }
+
+  if empty($filter) {
+    $filter_arg = ''
+  } else{
+    $filter_arg = "-filter=\"${filter}\""
+  }
+
+  if ($filter_with_deps == true) {
+    $filter_with_deps_arg = '-filter-with-deps'
+  } else{
+    $filter_with_deps_arg = ''
   }
 
   if $key {
@@ -115,7 +139,7 @@ define aptly::mirror (
   }
 
   exec { "aptly_mirror_create-${title}":
-    command     => "${aptly_cmd} create ${architectures_arg} -with-sources=${with_sources} -with-udebs=${with_udebs} ${title} ${location} ${release}${components_arg}",
+    command     => "${aptly_cmd} create ${architectures_arg} -with-sources=${with_sources} -with-udebs=${with_udebs} ${filter_arg} ${filter_with_deps_arg} ${title} ${location} ${release}${components_arg}",
     unless      => "${aptly_cmd} show ${title} >/dev/null",
     user        => $::aptly::user,
     require     => $exec_aptly_mirror_create_require,

--- a/spec/defines/mirror_spec.rb
+++ b/spec/defines/mirror_spec.rb
@@ -24,7 +24,7 @@ describe 'aptly::mirror' do
 
     it {
       should contain_exec('aptly_mirror_create-example').with({
-        :command => /aptly -config \/etc\/aptly.conf mirror create *-with-sources=false -with-udebs=false example http:\/\/repo\.example\.com precise$/,
+        :command => /aptly -config \/etc\/aptly.conf mirror create *-with-sources=false -with-udebs=false   example http:\/\/repo\.example\.com precise$/,
         :unless  => /aptly -config \/etc\/aptly.conf mirror show example >\/dev\/null$/,
         :user    => 'root',
         :require => [
@@ -72,7 +72,7 @@ describe 'aptly::mirror' do
 
       it {
         should contain_exec('aptly_mirror_create-example').with({
-          :command => /aptly -config \/etc\/aptly.conf mirror create *-with-sources=false -with-udebs=false example http:\/\/repo\.example\.com precise$/,
+          :command => /aptly -config \/etc\/aptly.conf mirror create *-with-sources=false -with-udebs=false   example http:\/\/repo\.example\.com precise$/,
           :unless  => /aptly -config \/etc\/aptly.conf mirror show example >\/dev\/null$/,
           :user    => 'custom_user',
           :require => [
@@ -222,7 +222,7 @@ describe 'aptly::mirror' do
 
       it {
         should contain_exec('aptly_mirror_create-example').with_command(
-          /aptly -config \/etc\/aptly.conf mirror create *-with-sources=false -with-udebs=false example http:\/\/repo\.example\.com precise main$/
+          /aptly -config \/etc\/aptly.conf mirror create *-with-sources=false -with-udebs=false   example http:\/\/repo\.example\.com precise main$/
         )
       }
     end
@@ -236,7 +236,7 @@ describe 'aptly::mirror' do
 
       it {
         should contain_exec('aptly_mirror_create-example').with_command(
-          /aptly -config \/etc\/aptly.conf mirror create *-with-sources=false -with-udebs=false example http:\/\/repo\.example\.com precise main contrib non-free$/
+          /aptly -config \/etc\/aptly.conf mirror create *-with-sources=false -with-udebs=false   example http:\/\/repo\.example\.com precise main contrib non-free$/
         )
       }
     end
@@ -264,7 +264,7 @@ describe 'aptly::mirror' do
 
       it {
 	should contain_exec('aptly_mirror_create-example').with_command(
-	  /aptly -config \/etc\/aptly.conf mirror create -architectures="amd64" -with-sources=false -with-udebs=false example http:\/\/repo\.example\.com precise$/
+	  /aptly -config \/etc\/aptly.conf mirror create -architectures="amd64" -with-sources=false -with-udebs=false   example http:\/\/repo\.example\.com precise$/
 	)
       }
     end
@@ -278,7 +278,7 @@ describe 'aptly::mirror' do
 
       it {
         should contain_exec('aptly_mirror_create-example').with_command(
-          /aptly -config \/etc\/aptly.conf mirror create -architectures="i386,amd64,armhf" -with-sources=false -with-udebs=false example http:\/\/repo\.example\.com precise$/
+          /aptly -config \/etc\/aptly.conf mirror create -architectures="i386,amd64,armhf" -with-sources=false -with-udebs=false   example http:\/\/repo\.example\.com precise$/
         )
       }
     end
@@ -306,7 +306,7 @@ describe 'aptly::mirror' do
 
       it {
         should contain_exec('aptly_mirror_create-example').with_command(
-          /aptly -config \/etc\/aptly.conf mirror create *-with-sources=true -with-udebs=false example http:\/\/repo\.example\.com precise$/
+          /aptly -config \/etc\/aptly.conf mirror create *-with-sources=true -with-udebs=false   example http:\/\/repo\.example\.com precise$/
         )
       }
     end
@@ -334,7 +334,51 @@ describe 'aptly::mirror' do
 
       it {
         should contain_exec('aptly_mirror_create-example').with_command(
-          /aptly -config \/etc\/aptly.conf mirror create *-with-sources=false -with-udebs=true example http:\/\/repo\.example\.com precise$/
+          /aptly -config \/etc\/aptly.conf mirror create *-with-sources=false -with-udebs=true   example http:\/\/repo\.example\.com precise$/
+        )
+      }
+    end
+  end
+
+  describe '#filter_with_deps' do
+    context 'not a boolean' do
+      let(:params) {{
+        :location         => 'http://repo.example.com',
+        :key              => 'ABC123',
+        :filter_with_deps => 'this is a string',
+      }}
+
+      it {
+        should raise_error(Puppet::Error, /is not a boolean/)
+      }
+    end
+
+    context 'with boolean true' do
+      let(:params) {{
+        :location         => 'http://repo.example.com',
+        :key              => 'ABC123',
+        :filter_with_deps => true,
+      }}
+
+      it {
+        should contain_exec('aptly_mirror_create-example').with_command(
+          /aptly -config \/etc\/aptly.conf mirror create *-with-sources=false -with-udebs=false  -filter-with-deps example http:\/\/repo\.example\.com precise$/
+        )
+      }
+    end
+  end
+
+  describe '#filter' do
+    context 'with filter' do
+      let(:params){{
+        :location   => 'http://repo.example.com',
+        :key        => 'ABC123',
+        :filter     => 'this is a string',
+      }}
+  
+      it {
+        should contain_exec('aptly_mirror_create-example').with_command(
+          /aptly -config \/etc\/aptly.conf mirror create *-with-sources=false -with-udebs=false -filter="this is a string"  example http:\/\/repo\.example\.com precise$/
         )
       }
     end


### PR DESCRIPTION
Hi Folks,

I had the requirement to mirror a repository with the -filter and -filter-with-deps switches to Aptly.  Not sure how common a use case this is but I use it when mirroring the Puppet repositories.

i.e.  aptly mirror create --architectures=amd64 --with-sources=false --filter='puppet (>= 3.8.6-1)' --filter-with-deps puppet http://apt.puppetlabs.com trusty main dependencies

so I've added these as parameters and thought I would share the change.  The addition of $filter and $filterwithdeps has the unfortunate effect of adding blank spaces to the aptly commands - I don't think this is very 'pretty' so feel free to suggest a better approach if there is one.

I'm using hiera in my setup and an example mirror definition would be:-

aptly::aptly_mirrors:
  'puppet':
    architectures: 
      - amd64
    filter: 'puppet (>= 3.8.6-1)'
    filter_with_deps: true
    key: '4BD6EC30'
    location: 'http://apt.puppetlabs.com'
    repos:
      - main
      - dependencies

Also I'm not that familiar with writing spec tests so have added new spec tests based on the existing tests so please be kind if they're really bad.

Thanks,
Trevor