### PR TITLE
Add config_file parameter to repo define

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -17,6 +17,9 @@
 #   Specify which component to put the package in. This option will only works
 #   for aptly version >= 0.5.0.
 #
+# [*config_file*]
+#   Specify the config file for the repository.
+#
 # [*distribution*]
 #   Specify the default distribution to be used when publishing this repository.
 
@@ -24,6 +27,7 @@ define aptly::repo(
   $architectures = [],
   $comment       = '',
   $component     = '',
+  $config_file   = '',
   $distribution  = '',
 ){
   validate_array($architectures)
@@ -33,13 +37,22 @@ define aptly::repo(
 
   include ::aptly
 
-  $aptly_cmd = "${::aptly::aptly_cmd} repo"
 
   if empty($architectures) {
     $architectures_arg = ''
   } else{
     $architectures_as_s = join($architectures, ',')
     $architectures_arg = "-architectures=\"${architectures_as_s}\""
+  }
+
+  if empty($config_file) {
+    $config_arg = "-config ${::aptly::config_file}"
+    $config     = $::aptly::config_file
+    $aptly_cmd  = "${::aptly::aptly_cmd} repo"
+  } else {
+    $config_arg = "-config ${config_file}"
+    $config     = $config_file
+    $aptly_cmd  = "/usr/bin/aptly ${config_arg} repo"
   }
 
   if empty($comment) {
@@ -66,7 +79,7 @@ define aptly::repo(
     user    => $::aptly::user,
     require => [
       Package['aptly'],
-      File['/etc/aptly.conf'],
+      File[$config],
     ],
   }
 }

--- a/spec/defines/repo_spec.rb
+++ b/spec/defines/repo_spec.rb
@@ -113,4 +113,36 @@ describe 'aptly::repo' do
     }
   end
 
+  describe 'custom config_file' do
+    context 'config_file set in aptly' do
+      let(:pre_condition)  { <<-EOS
+        class { 'aptly':
+          config_file => '/etc/custom_aptly.conf',
+        }
+        EOS
+      }
+      it {
+        should contain_exec('aptly_repo_create-example').with({
+          :command  => /aptly -config \/etc\/custom_aptly.conf repo create *example$/,
+          :unless   => /aptly -config \/etc\/custom_aptly.conf repo show example >\/dev\/null$/,
+          :user     => 'root',
+          :require  => [ 'Package[aptly]','File[/etc/custom_aptly.conf]' ],
+        })
+      }
+    end
+
+    context 'custom config_file for the repo' do
+      let(:params){{
+        :config_file => '/etc/custom_aptly_2.conf',
+      }}
+      it {
+        should contain_exec('aptly_repo_create-example').with({
+          :command  => /aptly -config \/etc\/custom_aptly_2.conf repo create *example$/,
+          :unless   => /aptly -config \/etc\/custom_aptly_2.conf repo show example >\/dev\/null$/,
+          :user     => 'root',
+          :require  => [ 'Package[aptly]','File[/etc/custom_aptly_2.conf]' ],
+        })
+      }
+    end
+  end
 end


### PR DESCRIPTION
If you're managing multiple aptly repositories on a single node you need
to be able to specify the config on a per-repo basis. This commit adds
the ability to pass a custom config for the repo commands, keeping the
existing default behavior. This code assumes you will be managing the
custom config files externally.