### PR TITLE
Update travis versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,16 +9,10 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.0
-  - 2.2.0
 env:
-  matrix:
-  - PUPPET_VERSION="~> 3.8.5"
-# This exclusion is because of https://tickets.puppetlabs.com/browse/PUP-3796
+  - PUPPET_VERSION="~> 3.8.0"
+  - PUPPET_VERSION="~> 4.6.0"
 matrix:
-  exclude:
-    - rvm: 2.2.0
-      env: PUPPET_VERSION="~> 3.8.5"
-# Only notify for failed builds.
-notifications:
-  email:
-    on_success: never
+  allow_failures:
+  - env: PUPPET_VERSION="~> 4.6.0"
+

--- a/Gemfile
+++ b/Gemfile
@@ -20,3 +20,8 @@ gem 'puppet-syntax', '2.0.0'
 # dependency of the system tests.
 gem 'fog', '1.34.0'
 gem 'fog-google', '0.1.0'
+
+# Older version required for ruby 1.9 compatability, as it is pulled in as dependency
+# of Puppet.  Versions of json_pure greater than 2.0.1 require Ruby 2.
+gem 'json_pure', '<= 2.0.1'
+gem 'json', '<= 1.8.3'


### PR DESCRIPTION
Standardise Travis configuration and versions
Only test on puppet versions we use.  Enable testing of Puppet 4 for future testing and upgrading.

Pin versions of Json to suite ruby version requirements
 These changes can be removed when we move away from Ruby 1.9.3