### PR TITLE
Stop pinning the stdlib version index in the fixture files

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,7 +2,7 @@ fixtures:
   repositories:
     stdlib:
       repo: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
-      ref: "3.0.0"
+      ref: "4.12.0"
     apt:
       repo: "git://github.com/puppetlabs/puppetlabs-apt.git"
       ref: "2.2.0"

--- a/metadata.json
+++ b/metadata.json
@@ -15,8 +15,8 @@
     }
    ],
   "dependencies": [
-    {"name": "puppetlabs/stdlib", "version_requirement": ">=3.0.0 <5.0.0"},
-    {"name": "puppetlabs/apt", "version_requirement": ">=2.0.0 <3.0.0"}
+    {"name": "puppetlabs/stdlib", "version_requirement": ">=3.0.0 <4.13.0"},
+    {"name": "puppetlabs/apt", "version_requirement": ">=2.0.0 <2.3.0"}
   ],
   "project_page": "https://github.com/gds-operations/puppet-aptly"
 }

--- a/spec/classes/api_spec.rb
+++ b/spec/classes/api_spec.rb
@@ -96,7 +96,7 @@ describe 'aptly::api' do
         :listen => false
       }}
 
-      it { should raise_error(Puppet::Error, /Valid values for \$listen: :port, <ip>:<port>/) }
+      it { should raise_error(Puppet::Error, /input needs to be a String/) }
     end
 
     context 'invalid format' do

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -10,7 +10,7 @@ describe 'aptly' do
     let(:params) {{ }}
 
     it { should contain_apt__source('aptly') }
-    it { should contain_package('aptly').that_requires('Apt::Update') }
+    it { should contain_package('aptly').that_requires('Class[Apt::Update]') }
     it { should contain_file('/etc/aptly.conf').with_content("{}\n") }
   end
 


### PR DESCRIPTION
Version 3.0 is too old for testing over all the versions we now care about. We're hoping that refining the version allowed in the metadata.json & .fixtures.yml file will pin the version correctly in both normal usage and testing.