### PR TITLE
Update usage of `apt::source`

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -69,11 +69,13 @@ class aptly (
 
   if $repo {
     apt::source { 'aptly':
-      location   => 'http://repo.aptly.info',
-      release    => 'squeeze',
-      repos      => 'main',
-      key_server => $key_server,
-      key        => 'DF32BC15E2145B3FA151AED19E3E53F19C7DE460',
+      location => 'http://repo.aptly.info',
+      release  => 'squeeze',
+      repos    => 'main',
+      key      => {
+        'server' => $key_server,
+        'id'     => 'DF32BC15E2145B3FA151AED19E3E53F19C7DE460',
+      },
     }
 
     Apt::Source['aptly'] -> Class['apt::update'] -> Package['aptly']

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -38,7 +38,10 @@ describe 'aptly' do
 
       it "should override apt::source (somekeyserver.com)" do
         should contain_apt__source('aptly').with(
-          :key_server => 'somekeyserver.com',
+          :key => {
+            'server' => 'somekeyserver.com',
+            'id' => 'DF32BC15E2145B3FA151AED19E3E53F19C7DE460'
+          },
         )
       end
     end


### PR DESCRIPTION
Newer versions of the `puppetlabs-apt` module throw deprecation warnings around the use of the `key_server` parameter. Update the usage to use the newer `key` parameter.