### PR TITLE
Bump version to 1.0.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "gdsoperations-aptly",
-  "version": "0.9.1",
+  "version": "1.0.0",
   "author": "Government Digital Service",
   "summary": "Module to manage aptly",
   "license": "MIT",


### PR DESCRIPTION
We've bumped the version number in the changelog with the conversion to PDK,
but we should also bump the version in metadata.json too!